### PR TITLE
Unify meaning of TDENEvent's encoding time for CMAF and MPEG-TS. Bump to v0.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The package can be installed by adding `ex_hls` to your list of dependencies in 
 ```elixir
 def deps do
   [
-    {:ex_hls, "~> 0.2.3"}
+    {:ex_hls, "~> 0.2.4"}
   ]
 end
 ```

--- a/lib/ex_hls/client/live/reader.ex
+++ b/lib/ex_hls/client/live/reader.ex
@@ -43,7 +43,8 @@ defmodule ExHLS.Client.Live.Reader do
       timestamp_offset: nil,
       playing_started?: false,
       segment_format: segment_format,
-      live_edge_mode?: live_edge_mode?
+      live_edge_mode?: live_edge_mode?,
+      current_segment_duration: nil
     }
 
     {:ok, state, {:continue, :setup}}
@@ -244,6 +245,7 @@ defmodule ExHLS.Client.Live.Reader do
 
     segment_content = Utils.download_or_read_file!(uri)
     state = maybe_resolve_demuxing_engine(segment.uri, state)
+    state = %{state | current_segment_duration: segment.duration}
     consume_segment_content(segment_content, state)
   end
 
@@ -429,9 +431,9 @@ defmodule ExHLS.Client.Live.Reader do
 
   defp maybe_adjust_tden_for_mpeg_ts(chunk, %{demuxing_engine_impl: ExHLS.DemuxingEngine.MPEGTS} = state) do
     with tden_tag when is_binary(tden_tag) <- chunk.metadata[:tden_tag],
-         target_duration when is_number(target_duration) <- state.media_playlist.info.target_duration,
+         duration when is_number(duration) <- state.current_segment_duration,
          {:ok, datetime, _offset} <- DateTime.from_iso8601(tden_tag) do
-      adjusted = DateTime.add(datetime, trunc(target_duration * 1000), :millisecond)
+      adjusted = DateTime.add(datetime, trunc(duration * 1000), :millisecond)
       %{chunk | metadata: Map.put(chunk.metadata, :tden_tag, DateTime.to_iso8601(adjusted))}
     else
       _ -> chunk

--- a/lib/ex_hls/client/live/reader.ex
+++ b/lib/ex_hls/client/live/reader.ex
@@ -443,11 +443,12 @@ defmodule ExHLS.Client.Live.Reader do
        ) do
     with tden_tag when is_binary(tden_tag) <- chunk.metadata[:tden_tag],
          duration when is_number(duration) <- state.current_segment_duration,
-         {:ok, datetime, _offset} <- DateTime.from_iso8601(tden_tag) do
-      adjusted = DateTime.add(datetime, trunc(duration * 1000), :millisecond)
-      %{chunk | metadata: Map.put(chunk.metadata, :tden_tag, DateTime.to_iso8601(adjusted))}
+         {:ok, datetime} <- NaiveDateTime.from_iso8601(tden_tag) do
+      adjusted = NaiveDateTime.add(datetime, trunc(duration * 1000), :millisecond)
+      %{chunk | metadata: Map.put(chunk.metadata, :tden_tag, NaiveDateTime.to_iso8601(adjusted))}
     else
-      _other -> chunk
+      _other ->
+        chunk
     end
   end
 

--- a/lib/ex_hls/client/live/reader.ex
+++ b/lib/ex_hls/client/live/reader.ex
@@ -429,7 +429,13 @@ defmodule ExHLS.Client.Live.Reader do
 
   defp maybe_resolve_demuxing_engine(_segment_uri, state), do: state
 
-  defp maybe_adjust_tden_for_mpeg_ts(chunk, %{demuxing_engine_impl: ExHLS.DemuxingEngine.MPEGTS} = state) do
+  # In MPEG-TS, the TDEN ID3 tag is placed at the start of the segment, so its timestamp reflects
+  # the segment's begin time. Offset it forward by the segment duration to get the end time,
+  # matching the semantics of TDEN in CMAF (where the tag is placed at the end of the segment).
+  defp maybe_adjust_tden_for_mpeg_ts(
+         chunk,
+         %{demuxing_engine_impl: ExHLS.DemuxingEngine.MPEGTS} = state
+       ) do
     with tden_tag when is_binary(tden_tag) <- chunk.metadata[:tden_tag],
          duration when is_number(duration) <- state.current_segment_duration,
          {:ok, datetime, _offset} <- DateTime.from_iso8601(tden_tag) do

--- a/lib/ex_hls/client/live/reader.ex
+++ b/lib/ex_hls/client/live/reader.ex
@@ -445,7 +445,7 @@ defmodule ExHLS.Client.Live.Reader do
     with tden_tag when tden_tag != nil <- chunk.metadata[:tden_tag],
          duration when duration != nil <- state.current_segment_duration,
          {:ok, datetime} <- NaiveDateTime.from_iso8601(tden_tag) do
-      adjusted = NaiveDateTime.add(datetime, trunc(duration * 1000), :millisecond)
+      adjusted = NaiveDateTime.add(datetime, round(duration * 1000), :millisecond)
       %{chunk | metadata: Map.put(chunk.metadata, :tden_tag, NaiveDateTime.to_iso8601(adjusted))}
     else
       _other ->

--- a/lib/ex_hls/client/live/reader.ex
+++ b/lib/ex_hls/client/live/reader.ex
@@ -308,6 +308,7 @@ defmodule ExHLS.Client.Live.Reader do
       {:ok, %ExHLS.Chunk{} = chunk, demuxing_engine} ->
         media_type = state.tracks_data[track_id].media_type
         chunk = %{chunk | media_type: media_type}
+        chunk = maybe_adjust_tden_for_mpeg_ts(chunk, state)
         Forwarder.feed_with_media_chunk(state.forwarder, media_type, chunk)
 
         ts = chunk_dts_or_pts_ms(chunk)
@@ -425,6 +426,19 @@ defmodule ExHLS.Client.Live.Reader do
   end
 
   defp maybe_resolve_demuxing_engine(_segment_uri, state), do: state
+
+  defp maybe_adjust_tden_for_mpeg_ts(chunk, %{demuxing_engine_impl: ExHLS.DemuxingEngine.MPEGTS} = state) do
+    with tden_tag when is_binary(tden_tag) <- chunk.metadata[:tden_tag],
+         target_duration when is_number(target_duration) <- state.media_playlist.info.target_duration,
+         {:ok, datetime, _offset} <- DateTime.from_iso8601(tden_tag) do
+      adjusted = DateTime.add(datetime, trunc(target_duration * 1000), :millisecond)
+      %{chunk | metadata: Map.put(chunk.metadata, :tden_tag, DateTime.to_iso8601(adjusted))}
+    else
+      _ -> chunk
+    end
+  end
+
+  defp maybe_adjust_tden_for_mpeg_ts(chunk, _state), do: chunk
 
   # workaround to mute dialyzer
   @spec chunk_dts_or_pts_ms(ExHLS.Chunk.t()) :: non_neg_integer() | nil

--- a/lib/ex_hls/client/live/reader.ex
+++ b/lib/ex_hls/client/live/reader.ex
@@ -442,7 +442,7 @@ defmodule ExHLS.Client.Live.Reader do
       adjusted = DateTime.add(datetime, trunc(duration * 1000), :millisecond)
       %{chunk | metadata: Map.put(chunk.metadata, :tden_tag, DateTime.to_iso8601(adjusted))}
     else
-      _ -> chunk
+      _other -> chunk
     end
   end
 

--- a/lib/ex_hls/client/live/reader.ex
+++ b/lib/ex_hls/client/live/reader.ex
@@ -245,7 +245,12 @@ defmodule ExHLS.Client.Live.Reader do
 
     segment_content = Utils.download_or_read_file!(uri)
     state = maybe_resolve_demuxing_engine(segment.uri, state)
-    state = %{state | current_segment_duration: segment.duration}
+
+    state =
+      if is_struct(segment, Segment),
+        do: %{state | current_segment_duration: segment.duration},
+        else: state
+
     consume_segment_content(segment_content, state)
   end
 

--- a/lib/ex_hls/client/live/reader.ex
+++ b/lib/ex_hls/client/live/reader.ex
@@ -247,9 +247,10 @@ defmodule ExHLS.Client.Live.Reader do
     state = maybe_resolve_demuxing_engine(segment.uri, state)
 
     state =
-      if is_struct(segment, Segment),
-        do: %{state | current_segment_duration: segment.duration},
-        else: state
+      case segment do
+        %Segment{duration: duration} -> %{state | current_segment_duration: duration}
+        _other -> state
+      end
 
     consume_segment_content(segment_content, state)
   end

--- a/lib/ex_hls/client/live/reader.ex
+++ b/lib/ex_hls/client/live/reader.ex
@@ -441,8 +441,8 @@ defmodule ExHLS.Client.Live.Reader do
          chunk,
          %{demuxing_engine_impl: ExHLS.DemuxingEngine.MPEGTS} = state
        ) do
-    with tden_tag when is_binary(tden_tag) <- chunk.metadata[:tden_tag],
-         duration when is_number(duration) <- state.current_segment_duration,
+    with tden_tag when tden_tag != nil <- chunk.metadata[:tden_tag],
+         duration when duration != nil <- state.current_segment_duration,
          {:ok, datetime} <- NaiveDateTime.from_iso8601(tden_tag) do
       adjusted = NaiveDateTime.add(datetime, trunc(duration * 1000), :millisecond)
       %{chunk | metadata: Map.put(chunk.metadata, :tden_tag, NaiveDateTime.to_iso8601(adjusted))}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExHLS.Mixfile do
   use Mix.Project
 
-  @version "0.2.3"
+  @version "0.2.4"
   @github_url "https://github.com/membraneframework/ex_hls"
 
   def project do


### PR DESCRIPTION
This PR:
* makes sure that TDEN encoding time corresponds to the timestamp of the last sample in the segment from which `TDEN` tag was read in both CMAF and MPEG-TS

This change was required since in `CMAF`'s `emsg` box the timestamp natively corresponds to the timestamp of the last sample in given chunk, but on contrary with `MPEG-TS` segments this timestamp correponds to the first sample of given segment.